### PR TITLE
Fix IndexOutOfBoundsException when loading JSGF grammars

### DIFF
--- a/Syn.Speech/Decoders/Search/Partitioner.cs
+++ b/Syn.Speech/Decoders/Search/Partitioner.cs
@@ -173,7 +173,7 @@ namespace Syn.Speech.Decoders.Search
          */
         private static int SimplePointSelect(Token[] tokens, int start, int end, int targetSize) 
         {
-            Array.Sort(tokens, start, end + 1, new ScoreableComparator());
+            Array.Sort(tokens, start, (end + 1) - start, new ScoreableComparator());
             return start + targetSize - 1;
         }
 

--- a/Syn.Speech/Jsgf/JSGFGrammar.cs
+++ b/Syn.Speech/Jsgf/JSGFGrammar.cs
@@ -767,10 +767,11 @@ namespace Syn.Speech.Jsgf
                         break;
                     }
                     // Extract rule name
+                    var endIndex = rule.IndexOf('>', index + 1);
                     JSGFRuleName extractedRuleName = new JSGFRuleName(rule
-                            .Substring(index + 1, rule.IndexOf('>', index + 1))
+                            .Substring(index + 1, endIndex - (index + 1))
                             .Trim());
-                    index = rule.IndexOf('>', index) + 1;
+                    index = endIndex + 1;
 
                     // Check for full qualified rule name
                     if (extractedRuleName.GetFullGrammarName() != null)


### PR DESCRIPTION
Hi,

Around line 770 of Syn.Speech/Jsgf/JSGFGrammar.cs, you're passing a string index to the 'length' parameter of Substring(index, length). This caused the loader to loadthe rule names incorrectly, and throw an exception for larger grammars.